### PR TITLE
Float minor RDS engine version in terraform template

### DIFF
--- a/aws/terraform/modules/metaflow/modules/datastore/rds.tf
+++ b/aws/terraform/modules/metaflow/modules/datastore/rds.tf
@@ -63,7 +63,7 @@ resource "aws_db_instance" "this" {
   storage_encrypted         = true
   kms_key_id                = aws_kms_key.rds.arn
   engine                    = "postgres"
-  engine_version            = "11.10"
+  engine_version            = "11"
   instance_class            = var.db_instance_type                                         # Hardware configuration
   identifier                = "${var.resource_prefix}${var.db_name}${var.resource_suffix}" # used for dns hostname needs to be customer unique in region
   name                      = var.db_name                                                  # unique id for CLI commands (name of DB table which is why we're not adding the prefix as no conflicts will occur and the API expects this table name)


### PR DESCRIPTION
Since we have `auto_minor_version_upgrade` set to on, setting it to `11.10` causes drift. That is, with the current version:

1. You deploy Metaflow using terraform template, including RDS instance with Postgres 11.10
2. At some point, AWS decides to upgrade it to 11.11
3. At some later point you make unrelated changes in your terraform config, and do `terraform apply`. Terraform detects that your code says that RDS is supposed to use 11.10 but in reality it is 11.11, so it offers to tear it down and recreate with 11.10 to reconcile => not good!