### PR TITLE
CFN stack now also generates an attachable IAM policy for Metaflow users

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -851,6 +851,109 @@ Resources:
                 Condition:
                   "Null":
                     events:source: true
+  MetaflowUserPolicy:
+    Condition: 'EnableRole'
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "cloudformation:DescribeStacks"
+              - "cloudformation:*Stack"
+              - "cloudformation:*ChangeSet"
+            Resource:
+              - !Sub "arn:${IAMPartition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-*"
+          - Effect: "Allow"
+            Action:
+              - "s3:*Object"
+            Resource:
+              - !GetAtt 'MetaflowS3Bucket.Arn'
+              - !Join ['', [ !GetAtt 'MetaflowS3Bucket.Arn', '/*' ]]
+          - Effect: "Allow"
+            Action:
+              - "sagemaker:DescribeNotebook*"
+              - "sagemaker:StartNotebookInstance"
+              - "sagemaker:StopNotebookInstance"
+              - "sagemaker:UpdateNotebookInstance"
+              - "sagemaker:CreatePresignedNotebookInstanceUrl"
+            Resource:
+              - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/${AWS::StackName}-*"
+              - !Sub "arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance-lifecycle-config/basic*"
+          - Effect: "Allow"
+            Action:
+              - "iam:PassRole"
+            Resource:
+              - !Sub "arn:${IAMPartition}:iam::${AWS::AccountId}:role/${AWS::StackName}-*"
+          - Effect: "Allow"
+            Action:
+              - "kms:Decrypt"
+              - "kms:Encrypt"
+            Resource:
+              - !Sub "arn:${IAMPartition}:kms:${AWS::Region}:${AWS::AccountId}:key/"
+          - Sid: JobsPermissions
+            Effect: Allow
+            Action:
+              - "batch:TerminateJob"
+              - "batch:DescribeJobs"
+              - "batch:DescribeJobDefinitions"
+              - "batch:DescribeJobQueues"
+              - "batch:RegisterJobDefinition"
+              - "batch:DescribeComputeEnvironments"
+            Resource: '*'
+          - Sid: DefinitionsPermissions
+            Effect: Allow
+            Action:
+              - "batch:SubmitJob"
+            Resource:
+              - !Ref "JobQueue"
+              - !Sub arn:${IAMPartition}:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*:*
+          - Sid: BucketAccess
+            Effect: Allow
+            Action: s3:ListBucket
+            Resource: !GetAtt 'MetaflowS3Bucket.Arn'
+          - Sid: GetLogs
+            Effect: Allow
+            Action: logs:GetLogEvents
+            Resource: !Sub arn:${IAMPartition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:log-stream:*
+          - Sid: AllowSagemakerCreate
+            Effect: Allow
+            Action: sagemaker:CreateTrainingJob
+            Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+          - Sid: AllowSagemakerDescribe
+            Effect: Allow
+            Action: sagemaker:DescribeTrainingJob
+            Resource: !Sub arn:${IAMPartition}:sagemaker:${AWS::Region}:${AWS::AccountId}:training-job/*
+          - Sid: TasksAndExecutionsGlobal
+            Effect: Allow
+            Action:
+              - "states:ListStateMachines"
+            Resource: '*'
+          - Sid: StateMachines
+            Effect: Allow
+            Action:
+              - "states:DescribeStateMachine"
+              - "states:UpdateStateMachine"
+              - "states:StartExecution"
+              - "states:CreateStateMachine"
+              - "states:ListExecutions"
+              - "states:StopExecution"
+            Resource: !Sub 'arn:${IAMPartition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:*'
+          - Sid: RuleMaintenance
+            Effect: Allow
+            Action:
+              - "events:PutTargets"
+              - "events:DisableRule"
+            Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/*"
+          - Sid: PutRule
+            Effect: Allow
+            Action:
+              - "events:PutRule"
+            Resource: !Sub "arn:${IAMPartition}:events:${AWS::Region}:${AWS::AccountId}:rule/*"
+            Condition:
+              "Null":
+                events:source: true
   EventBridgeRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## The problem
Currently CFN template can generate an IAM _role_ that could be assumed by any code that needs to interact with Metaflow. It would allow access to the S3 bucket, step functions and whatnot.

I've found that often I already have an IAM role that I'm using for whatever reason, that may have access to some other AWS stuff. Once I deploy Metaflow template, it would be helpful if CFN would instead just generate a policy (_"customer managed policy"_ in AWS terminology) that could attach to that existing role to allow it to use Metaflow as well.

## Solution

This PR adds a block to the CFN template that generates a customer managed policy that allows access to Metaflow resources. It is controlled by the same flag as the IAM role, just to keep things simple.