### PR TITLE
Pin service version in CFN template

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -93,7 +93,7 @@ Mappings:
     ServiceName:
       value: 'metadata-service-v2'
     ImageUrl:
-      value: 'netflixoss/metaflow_metadata_service'
+      value: 'netflixoss/metaflow_metadata_service:v2.2.3'
     ContainerPort:
       value: 8080
     ContainerCpu:
@@ -114,7 +114,7 @@ Mappings:
     ServiceName:
       value: 'metaflow-ui-service'
     ImageUrl:
-      value: 'netflixoss/metaflow_metadata_service'
+      value: 'netflixoss/metaflow_metadata_service:v2.2.3'
     ContainerPort:
       value: 8083
     ContainerCpu:
@@ -135,7 +135,7 @@ Mappings:
     ServiceName:
       value: 'metadata-ui-static'
     ImageUrl:
-      value: 'public.ecr.aws/outerbounds/metaflow_ui:v1.0.1'
+      value: 'public.ecr.aws/outerbounds/metaflow_ui:v1.1.1'
     ContainerPort:
       value: 3000
     ContainerCpu:


### PR DESCRIPTION
Seems prudent to not use a floating version for docker tags (we already do the same in Terraform)