### PR TITLE
added command for livenessprobe

### DIFF
--- a/azure/terraform/services/airflow/helm-values.yml
+++ b/azure/terraform/services/airflow/helm-values.yml
@@ -31,3 +31,10 @@ secret:
 
 
 webserverSecretKey: ${airflow_frenet_secret}
+
+scheduler:
+  livenessProbe:
+    command:
+      - sh
+      - -c
+      - CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint airflow jobs check --job-type SchedulerJob


### PR DESCRIPTION
When deploying the services using Azure Kubernetes and Airflow as an orchestrator, the liveness probe is failing for the Airflow Scheduler pod. 

![image](https://user-images.githubusercontent.com/37203334/195686867-fa053c01-b24c-4a96-b816-0330b9303430.png)

The issue is also described here:  [Airflow repository](https://github.com/apache/airflow/issues/25667)

When removing the `--hostname` argument, the liveness probe does not fail



