### PR TITLE
AWS CFT fix SageMaker Notebook lifecycle config

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -1127,7 +1127,7 @@ Resources:
                 echo 'export AWS_DEFAULT_REGION=${AWS::Region}' >> /etc/profile.d/jupyter-env.sh
                 echo 'export METAFLOW_DEFAULT_DATASTORE=s3' >> /etc/profile.d/jupyter-env.sh
                 echo 'export METAFLOW_DEFAULT_METADATA=service' >> /etc/profile.d/jupyter-env.sh
-                initctl restart jupyter-server --no-wait
+                systemctl restart jupyter-server
       OnStart:
         - Content:
             Fn::Base64:


### PR DESCRIPTION
Found this while some teammates were spinning up a Metaflow stack as part of a hackathon:

When deploying the AWS CloudFormation stack, if the SageMaker Notebook param is enabled there will be an error:
```
The following resource(s) failed to create: [SageMakerNotebookInstance]. Rollback requested by user.

Notebook Instance Lifecycle Config 'arn:aws:sagemaker:us-east-1:xxx:notebook-instance-lifecycle-config/basicnotebookinstancelifecycleconfig-s8ydcbss7bcb' for Notebook Instance 'arn:aws:sagemaker:us-east-1:xxx:notebook-instance/hackathon2023-notebookinstance-xru98eyd' took longer than 5 minutes. Please check your CloudWatch logs for more details if your Notebook Instance has Internet access.
```

Digging into the SageMaker Notebook instance logs, we can find it's from this:
```
/tmp/OnCreate_2023-01-24-18-3833l4zk30: line 8: initctl: command not found
```

This looks to be due to SageMaker swapping from Amazon Linux 1 to Amazon Linux 2, with further discussion here https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples/issues/76

After updating the lifecycle config for the new command, the stack was created successfully and notebook instance had the expected metaflow params preconfigured.