### PR TITLE
allow to specify db schema name in the helm chart

### DIFF
--- a/k8s/helm/metaflow/charts/metaflow-service/Chart.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.2.4
+appVersion: v2.3.6
 description: A Helm chart to deploy Metadata Service for Metaflow
 name: metaflow-service
 type: application

--- a/k8s/helm/metaflow/charts/metaflow-service/templates/_helpers.tpl
+++ b/k8s/helm/metaflow/charts/metaflow-service/templates/_helpers.tpl
@@ -76,5 +76,9 @@ Create the name of the service account to use
 {{- else }}
 - name: MF_METADATA_DB_HOST
   value: {{ .Release.Name }}-postgresql
-{{- end -}}
+{{- end }}
+{{- if .Values.metadatadb.schema }}
+- name: DB_SCHEMA_NAME
+  value: {{ .Values.metadatadb.schema | quote }}
+{{- end }}
 {{- end -}}

--- a/k8s/helm/metaflow/charts/metaflow-ui/Chart.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 2.1.0
+appVersion: v2.3.6
 description: A Helm chart for Kubernetes
 name: metaflow-ui
 type: application
-version: 0.1.0
+version: 0.1.1

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
@@ -111,4 +111,8 @@ Create the name of the service account to use
 - name: MF_METADATA_DB_HOST
   value: {{ .Release.Name }}-postgresql
 {{- end -}}
+{{- if .Values.metadatadb.schema }}
+- name: DB_SCHEMA_NAME
+  value: {{ .Values.metadatadb.schema | quote }}
+{{- end }}
 {{- end -}}

--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: netflixoss/metaflow_metadata_service
+  repository: public.ecr.aws/outerbounds/metaflow_metadata_service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
You can now use `metadatadb.schema` in helm values to specify the default schema name if its different from `public` in your PostgreSQL setup. Note that the specified schema still needs to be first on PostgreSQL `search_path`