### PR TITLE
Bump up the version to avoid DAG display error

### DIFF
--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -13,7 +13,7 @@ image:
 uiImage:
   repository: public.ecr.aws/outerbounds/metaflow_ui
   pullPolicy: IfNotPresent
-  tag: "v1.0.1"
+  tag: "v1.1.4"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Original dag error with v1.0.1:
```
TypeError: Cannot read properties of undefined (reading 'box_ends')
```

Resolution: Upgraded to v1.1.4 (which is used in GCP and Azure terraform)

Tested with K8s set up.