### PR TITLE
Bump up the version of the static UI container to avoid DAG display error

### DIFF
--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -13,7 +13,7 @@ image:
 uiImage:
   repository: public.ecr.aws/outerbounds/metaflow_ui
   pullPolicy: IfNotPresent
-  tag: "v1.0.1"
+  tag: "v1.1.4"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
With v1.0.1 and the other containers at 2.3.1/2.3.6, you see this error while fetching the dag:
```TypeError: Cannot read properties of undefined (reading 'box_ends')```

Previous PR has fixed it similarly for terraform scripts: https://github.com/outerbounds/metaflow-tools/pull/8/files

Updating it to 1.1.4 based on Azure/GCP terraform.