### PR TITLE
Add argo_events/ terraform module

### DIFF
--- a/common/terraform/argo_events/argo-events-helper-chart/.helmignore
+++ b/common/terraform/argo_events/argo-events-helper-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/common/terraform/argo_events/argo-events-helper-chart/Chart.yaml
+++ b/common/terraform/argo_events/argo-events-helper-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: argo-events-helper-chart
+description: Helper chart that contains EventBus and EventSource definitions.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/common/terraform/argo_events/argo-events-helper-chart/templates/eventbus.yaml
+++ b/common/terraform/argo_events/argo-events-helper-chart/templates/eventbus.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  namespace: {{ .Values.jobsNamespace }}
+spec:
+  jetstream:
+    version: 2.9.15
+    containerTemplate:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi

--- a/common/terraform/argo_events/argo-events-helper-chart/templates/eventsource.yaml
+++ b/common/terraform/argo_events/argo-events-helper-chart/templates/eventsource.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: argo-events-webhook
+  namespace: {{ .Values.jobsNamespace }}
+spec:
+  template:
+    container:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 50Mi
+        limits:
+          cpu: 50m
+          memory: 50Mi
+  service:
+    ports:
+      - port: 12000
+        targetPort: 12000
+  webhook:
+    metaflow-event:
+      port: "12000"
+      endpoint: /metaflow-event
+      method: POST

--- a/common/terraform/argo_events/argo-events-helper-chart/values.yaml
+++ b/common/terraform/argo_events/argo-events-helper-chart/values.yaml
@@ -1,0 +1,1 @@
+jobsNamespace: default

--- a/common/terraform/argo_events/main.tf
+++ b/common/terraform/argo_events/main.tf
@@ -1,0 +1,191 @@
+locals {
+  argo_events_values = {
+    "configs" = {
+      "jetstream" = {
+        "versions" = [
+          {
+            "configReloaderImage"  = "natsio/nats-server-config-reloader:latest"
+            "metricsExporterImage" = "natsio/prometheus-nats-exporter:latest"
+            "natsImage"            = "nats:latest"
+            "startCommand"         = "/nats-server"
+            "version"              = "latest"
+          },
+          {
+            "configReloaderImage"  = "natsio/nats-server-config-reloader:latest"
+            "metricsExporterImage" = "natsio/prometheus-nats-exporter:latest"
+            "natsImage"            = "nats:2.9.15"
+            "startCommand"         = "/nats-server"
+            "version"              = "2.9.15"
+          },
+        ]
+      }
+    }
+    "controller" = {
+      "name" = "controller-manager"
+      "rbac" = {
+        "enabled"    = true
+        "namespaced" = false
+      }
+      "resources" = {
+        "limits" = {
+          "cpu"    = "200m"
+          "memory" = "192Mi"
+        }
+        "requests" = {
+          "cpu"    = "200m"
+          "memory" = "192Mi"
+        }
+      }
+      "serviceAccount" = {
+        "create" = true
+        "name"   = "argo-events-events-controller-sa"
+      }
+    }
+    "crds" = {
+      "keep" = true
+    }
+    "extraObjects" = [
+      {
+        "apiVersion" = "v1"
+        "kind"       = "ServiceAccount"
+        "metadata" = {
+          "name"      = "operate-workflow-sa"
+          "namespace" = var.jobs_namespace
+        }
+      },
+      {
+        "apiVersion" = "rbac.authorization.k8s.io/v1"
+        "kind"       = "Role"
+        "metadata" = {
+          "name"      = "operate-workflow-role"
+          "namespace" = var.jobs_namespace
+        }
+        "rules" = [
+          {
+            "apiGroups" = [
+              "argoproj.io",
+            ]
+            "resources" = [
+              "workflows",
+              "workflowtemplates",
+              "cronworkflows",
+              "clusterworkflowtemplates",
+            ]
+            "verbs" = [
+              "*",
+            ]
+          },
+        ]
+      },
+      {
+        "apiVersion" = "rbac.authorization.k8s.io/v1"
+        "kind"       = "RoleBinding"
+        "metadata" = {
+          "name"      = "operate-workflow-role-binding"
+          "namespace" = var.jobs_namespace
+        }
+        "roleRef" = {
+          "apiGroup" = "rbac.authorization.k8s.io"
+          "kind"     = "Role"
+          "name"     = "operate-workflow-role"
+        }
+        "subjects" = [
+          {
+            "kind" = "ServiceAccount"
+            "name" = "operate-workflow-sa"
+          },
+        ]
+      },
+      {
+        "apiVersion" = "rbac.authorization.k8s.io/v1"
+        "kind"       = "Role"
+        "metadata" = {
+          "name"      = "view-events-role"
+          "namespace" = var.jobs_namespace
+        }
+        "rules" = [
+          {
+            "apiGroups" = [
+              "argoproj.io",
+            ]
+            "resources" = [
+              "eventsources",
+              "eventbuses",
+              "sensors",
+            ]
+            "verbs" = [
+              "get",
+              "list",
+              "watch",
+            ]
+          },
+        ]
+      },
+      {
+        "apiVersion" = "rbac.authorization.k8s.io/v1"
+        "kind"       = "RoleBinding"
+        "metadata" = {
+          "name"      = "view-events-role-binding"
+          "namespace" = var.jobs_namespace
+        }
+        "roleRef" = {
+          "apiGroup" = "rbac.authorization.k8s.io"
+          "kind"     = "Role"
+          "name"     = "view-events-role"
+        }
+        "subjects" = [
+          {
+            "kind"      = "ServiceAccount"
+            "name"      = "argo-workflows"
+            "namespace" = "argo-workflows"
+          },
+        ]
+      },
+    ]
+  }
+}
+
+resource "kubernetes_namespace" "argo_events" {
+  metadata {
+    name = "argo-events"
+  }
+}
+
+resource "helm_release" "argo_events" {
+  name = "argo-events"
+
+  repository   = "https://argoproj.github.io/argo-helm"
+  chart        = "argo-events"
+  namespace    = kubernetes_namespace.argo_events.metadata[0].name
+  force_update = true
+
+  values = [
+    yamlencode(local.argo_events_values)
+  ]
+}
+
+
+resource "helm_release" "argo_events_helper_chart" {
+  # We define an EventBus and EventSource in this helper chart. This is one
+  # of the cleaner workarounds for the chicken-egg problem with CR and CRD definitions
+  # in "terraform plan". E.g. Terraform tries to validate the kind "EventBus" before it
+  # has been created in the cluster, causing the validation to fail.
+  #
+  # Mega-thread here: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1367
+  name = "argo-events-helper-chart"
+
+  depends_on = [helm_release.argo_events]
+
+  chart        = "${path.module}/argo-events-helper-chart"
+  namespace    = kubernetes_namespace.argo_events.metadata[0].name
+  force_update = true
+
+  set {
+    name  = "jobsNamespace"
+    value = var.jobs_namespace
+  }
+}
+
+variable "jobs_namespace" {
+  type = string
+}


### PR DESCRIPTION
This is moved as-is from [terraform-aws-metaflow](https://github.com/outerbounds/terraform-aws-metaflow).  It was recently added there.

Goal is to have `common/terraform/argo_events` be the primary copy and other repos and templates will load TF module directly over [git protocol](https://developer.hashicorp.com/terraform/language/modules/sources#github).

I.e. [terraform-aws-metaflow](https://github.com/outerbounds/terraform-aws-metaflow)'s references to `argo_events` will be updated to load like this:

```
 module "argo_events" {
   depends_on     = [helm_release.argo]
-  source         = "./argo_events"
+  source         = "git::git@github.com:outerbounds/metaflow-tools//common/terraform/argo_events?ref=<SOME_PIN>"
   jobs_namespace = "default"
 }
```

Azure / GCP terraform templates from THIS repo can also do the same (git pin) - though local dir references will work just fine as well (TBD).