### PR TITLE
[azure terraform] argo events support

### DIFF
--- a/azure/terraform/.gitignore
+++ b/azure/terraform/.gitignore
@@ -1,0 +1,2 @@
+*.tfvars
+config.json

--- a/azure/terraform/forward_metaflow_ports.py
+++ b/azure/terraform/forward_metaflow_ports.py
@@ -1,0 +1,1 @@
+../../scripts/forward_metaflow_ports.py

--- a/azure/terraform/output.tf
+++ b/azure/terraform/output.tf
@@ -33,18 +33,9 @@ STEP 2: Configure Metaflow:
 
 Option 1: Create JSON config directly
 
-Create the file "~/.metaflowconfig/config.json" with this content. If this file already exists, keep a backup of it and move it aside first. 
-{
-    "METAFLOW_AZURE_STORAGE_BLOB_SERVICE_ENDPOINT": "${data.azurerm_storage_account.default.primary_blob_endpoint}",
-    "METAFLOW_DATASTORE_SYSROOT_AZURE": "${local.metaflow_datastore_sysroot_azure}",
-    "METAFLOW_DEFAULT_DATASTORE": "azure",
-    "METAFLOW_DEFAULT_METADATA": "service",
-    "METAFLOW_KUBERNETES_NAMESPACE": "default",
-    "METAFLOW_KUBERNETES_SECRETS": "${local.metaflow_kubernetes_secret_name}",
-    "METAFLOW_KUBERNETES_SERVICE_ACCOUNT": "default",
-    "METAFLOW_SERVICE_INTERNAL_URL": "http://metadata-service.default:8080/",
-    "METAFLOW_SERVICE_URL": "http://127.0.0.1:8080/"
-}
+Copy config.json to ~/.metaflowconfig/config.json:
+
+$ cp config.json ~/.metaflowconfig/config.json
 
 If deployed with Airflow or Argo then remove the `METAFLOW_KUBERNETES_SERVICE_ACCOUNT` key from the json file. 
 If deployed with Airflow set `METAFLOW_KUBERNETES_NAMESPACE` to "airflow". 
@@ -84,7 +75,7 @@ $ kubectl port-forward -n argo deployment/argo-server 2746:2746
 
 option 2 - this script manages the same port-forwards for you (and prevents timeouts)
 
-$ python metaflow-tools/scripts/forward_metaflow_ports.py [--include-argo] [--include-airflow]
+$ python forward_metaflow_ports.py [--include-argo] [--include-airflow]
 
 STEP 4: Install Azure Python SDK
 $ pip install azure-storage-blob azure-identity

--- a/azure/terraform/services/argo_events.tf
+++ b/azure/terraform/services/argo_events.tf
@@ -1,0 +1,5 @@
+module "argo_events" {
+  depends_on     = [null_resource.argo-quick-start-installation]
+  source         = "../../../common/terraform/argo_events"
+  jobs_namespace = "argo"
+}

--- a/azure/terraform/services/metaflow_config.tf
+++ b/azure/terraform/services/metaflow_config.tf
@@ -1,0 +1,18 @@
+resource "local_file" "metaflow_config_file" {
+  content = jsonencode({
+    "METAFLOW_AZURE_STORAGE_BLOB_SERVICE_ENDPOINT" = var.metaflow_azure_storage_blob_service_endpoint
+    "METAFLOW_DATASTORE_SYSROOT_AZURE"             = var.metaflow_datastore_sysroot_azure
+    "METAFLOW_DEFAULT_DATASTORE"                   = "azure"
+    "METAFLOW_DEFAULT_METADATA"                    = "service"
+    "METAFLOW_KUBERNETES_NAMESPACE"                = "default"
+    "METAFLOW_KUBERNETES_SECRETS"                  = var.metaflow_kubernetes_secret_name
+    "METAFLOW_KUBERNETES_SERVICE_ACCOUNT"          = "default"
+    "METAFLOW_SERVICE_INTERNAL_URL"                = "http://metadata-service.default:8080/"
+    "METAFLOW_SERVICE_URL"                         = "http://127.0.0.1:8080/"
+    "METAFLOW_ARGO_EVENTS_EVENT_BUS"               = "default"
+    "METAFLOW_ARGO_EVENTS_EVENT_SOURCE"            = "argo-events-webhook"
+    "METAFLOW_ARGO_EVENTS_EVENT"                   = "metaflow-event"
+    "METAFLOW_ARGO_EVENTS_WEBHOOK_URL"             = "http://argo-events-webhook-eventsource-svc.argo:12000/metaflow-event"
+  })
+  filename = "./config.json"
+}


### PR DESCRIPTION
Install argo-events related components, to support upcoming event triggering functionality in Metaflow.

Some quality of life drivebys:
* symlink `forward_metaflow_ports.py` to simplify usage instructions.
* generate metaflow config.json, instead of asking operator to copy and paste raw text around.