### PR TITLE
Refactor metaflow-ui helm chart and upgrade image versions

### DIFF
--- a/k8s/helm/metaflow/Chart.yaml
+++ b/k8s/helm/metaflow/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
   condition: metaflow-service.enabled
 - name: metaflow-ui
   repository: ""
-  version: 0.1.0
+  version: 0.2.0
   condition: metaflow-ui.enabled
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami

--- a/k8s/helm/metaflow/charts/metaflow-ui/Chart.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v2.3.6
+appVersion: v2.3.11
 description: A Helm chart for Kubernetes
 name: metaflow-ui
 type: application
-version: 0.1.1
+version: 0.2.0

--- a/k8s/helm/metaflow/charts/metaflow-ui/README.md
+++ b/k8s/helm/metaflow/charts/metaflow-ui/README.md
@@ -1,0 +1,3 @@
+## Helm Chart for Metaflow UI
+
+This helm chart deploys the static and backend components of the metaflow UI. It assumes that these deployments will mostly share similar configurations like `imagePullSecrets`, `tolerations`, and `affinity`. However, you can also configure the static and backend components separately via the `uiStatic` and `uiBackend` blocks respectively. Plus the helm chart also includes a way to configure the ingress resources that can optionally be deployed to server the metaflow UI.

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/NOTES.txt
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/NOTES.txt
@@ -5,16 +5,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.uiBackend.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "metaflow-ui.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.uiBackend.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "metaflow-ui.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "metaflow-ui.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.uiBackend.service.port }}
+{{- else if contains "ClusterIP" .Values.uiBackend.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "metaflow-ui.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
@@ -97,22 +97,22 @@ Create the name of the service account to use
 
 {{- define "metaflow-ui.metadatadbEnvVars" -}}
 - name: MF_METADATA_DB_NAME
-  value: {{ .Values.metadatadb.name | quote }}
+  value: {{ .Values.uiBackend.metadatadb.name | quote }}
 - name: MF_METADATA_DB_PORT
-  value: {{ .Values.metadatadb.port | quote }}
+  value: {{ .Values.uiBackend.metadatadb.port | quote }}
 - name: MF_METADATA_DB_PSWD
-  value: {{ .Values.metadatadb.password | quote }}
+  value: {{ .Values.uiBackend.metadatadb.password | quote }}
 - name: MF_METADATA_DB_USER
-  value: {{ .Values.metadatadb.user | quote }}
-{{- if .Values.metadatadb.host }}
+  value: {{ .Values.uiBackend.metadatadb.user | quote }}
+{{- if .Values.uiBackend.metadatadb.host }}
 - name: MF_METADATA_DB_HOST
-  value: {{ .Values.metadatadb.host | quote }}
+  value: {{ .Values.uiBackend.metadatadb.host | quote }}
 {{- else }}
 - name: MF_METADATA_DB_HOST
   value: {{ .Release.Name }}-postgresql
 {{- end -}}
-{{- if .Values.metadatadb.schema }}
+{{- if .Values.uiBackend.metadatadb.schema }}
 - name: DB_SCHEMA_NAME
-  value: {{ .Values.metadatadb.schema | quote }}
+  value: {{ .Values.uiBackend.metadatadb.schema | quote }}
 {{- end }}
 {{- end -}}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
@@ -61,8 +61,10 @@ spec:
               value: {{ .Values.uiBackend.metaflowDatastoreSysRootS3 | quote }}
             - name: METAFLOW_DATASTORE_SYSROOT_S3
               value: {{ .Values.uiBackend.metaflowDatastoreSysRootS3 | quote }}
+            {{- if .Values.uiBackend.metaflowS3EndpointURL }}
             - name: METAFLOW_S3_ENDPOINT_URL
               value: {{ .Values.uiBackend.metaflowS3EndpointURL | quote }}
+            {{- end }}
             - name: LOGLEVEL
               value: "DEBUG"
             - name: METAFLOW_SERVICE_URL

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
@@ -5,15 +5,13 @@ metadata:
   labels:
     {{- include "metaflow-ui.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ .Values.uiBackend.replicaCount }}
   selector:
     matchLabels:
       {{- include "metaflow-ui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.uiBackend.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,9 +29,9 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.uiBackend.image.name }}:{{ .Values.uiBackend.image.tag | default .Chart.AppVersion }}"
           command: ["/opt/latest/bin/python3", "-m", "services.ui_backend_service.ui_server" ]
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.uiBackend.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8083
@@ -46,12 +44,12 @@ spec:
             httpGet:
               path: /api/ping
               port: http
-          {{- with .Values.envFrom }}
+          {{- with .Values.uiBackend.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- range .Values.env }}
+            {{- range .Values.uiBackend.env }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}
             {{- end }}
@@ -60,20 +58,22 @@ spec:
             - name: PATH_PREFIX
               value: "/api"
             - name: MF_DATASTORE_ROOT
-              value: {{ .Values.METAFLOW_DATASTORE_SYSROOT_S3 | quote }}
+              value: {{ .Values.uiBackend.metaflowDatastoreSysRootS3 | quote }}
             - name: METAFLOW_DATASTORE_SYSROOT_S3
-              value: {{ .Values.METAFLOW_DATASTORE_SYSROOT_S3 | quote }}
+              value: {{ .Values.uiBackend.metaflowDatastoreSysRootS3 | quote }}
+            - name: METAFLOW_S3_ENDPOINT_URL
+              value: {{ .Values.uiBackend.metaflowS3EndpointURL | quote }}
             - name: LOGLEVEL
               value: "DEBUG"
             - name: METAFLOW_SERVICE_URL
-              value: "http://localhost:8083/api/metadata"
+              value: {{ .Values.uiBackend.metaflowServiceURL | quote }}
             - name: METAFLOW_DEFAULT_DATASTORE
               value: "s3"
             - name: METAFLOW_DEFAULT_METADATA
               value: "service"
             {{- include "metaflow-ui.metadatadbEnvVars" . | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.uiBackend.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_service.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/backend_service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "metaflow-ui.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.uiBackend.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.uiBackend.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/ingress.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "metaflow-ui.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.uiBackend.service.port -}}
 {{- $fullNameStatic := include "metaflow-ui.fullname-static" . -}}
-{{- $svcPortStatic := .Values.serviceStatic.port -}}
+{{- $svcPortStatic := .Values.uiStatic.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "metaflow-ui.labelsStatic" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ .Values.uiStatic.replicaCount }}
   selector:
     matchLabels:
       {{- include "metaflow-ui.selectorLabelsStatic" . | nindent 6 }}
@@ -31,8 +29,8 @@ spec:
         - name: "{{ .Chart.Name }}-static"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.uiImage.repository }}:{{ .Values.uiImage.tag }}"
-          imagePullPolicy: {{ .Values.uiImage.pullPolicy }}
+          image: "{{ .Values.uiStatic.image.name }}:{{ .Values.uiStatic.image.tag }}"
+          imagePullPolicy: {{ .Values.uiStatic.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 3000
@@ -45,8 +43,15 @@ spec:
             httpGet:
               path: /
               port: http
+          env:
+            - name: METAFLOW_SERVICE
+              value:  {{ .Values.uiStatic.metaflowUIBackendURL | quote }}
+            {{- range .Values.env }}
+            - name: {{ .name | quote }}
+              value: {{ .value | quote }}
+            {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.uiStatic.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/static_service.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/static_service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "metaflow-ui.labelsStatic" . | nindent 4 }}
 spec:
-  type: {{ .Values.serviceStatic.type }}
+  type: {{ .Values.uiStatic.service.type }}
   ports:
-    - port: {{ .Values.serviceStatic.port }}
+    - port: {{ .Values.uiStatic.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/tests/test-connection.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "metaflow-ui.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "metaflow-ui.fullname" . }}:{{ .Values.uiBackend.service.port }}']
   restartPolicy: Never

--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -2,11 +2,12 @@ uiBackend:
   image:
     name: public.ecr.aws/outerbounds/metaflow_metadata_service
     pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
   podAnnotations: {}
 
-  env:
+  env: []
     # Additional environment variables for metaflow-ui static deployment. Example config:
     # - name: METAFLOW_SERVICE
     #   value: "http://localhost:8083/api/"
@@ -119,6 +120,3 @@ ingress:
         - path: /api
           pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local

--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -1,25 +1,102 @@
-# Default values for metaflow-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+uiBackend:
+  image:
+    name: public.ecr.aws/outerbounds/metaflow_metadata_service
+    pullPolicy: IfNotPresent
+    tag: ""
 
-replicaCount: 1
+  podAnnotations: {}
 
-image:
-  repository: public.ecr.aws/outerbounds/metaflow_metadata_service
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  env:
+    # Additional environment variables for metaflow-ui static deployment. Example config:
+    # - name: METAFLOW_SERVICE
+    #   value: "http://localhost:8083/api/"
 
-uiImage:
-  repository: public.ecr.aws/outerbounds/metaflow_ui
-  pullPolicy: IfNotPresent
-  tag: "v1.1.4"
+  envFrom: []
 
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  service:
+    type: ClusterIP
+    port: 8083
+
+  replicaCount: 1
+
+  metaflowDatastoreSysRootS3: ""
+    # The root S3 bucket prefix that will be used by metaflow
+  
+  metaflowServiceURL: "http://localhost:8083/api/metadata"
+    # The metaflow metadata service URL 
+
+  metaflowS3EndpointURL: ""
+    # This should be set only when using an S3 compatible object storage like minio
+
+  metadatadb:
+    port: 5432
+    password: ""
+    host: ""
+    user: ""
+
+uiStatic:
+  image:
+    name: public.ecr.aws/outerbounds/metaflow_ui
+    pullPolicy: IfNotPresent
+    tag: "v1.3.3"
+
+  podAnnotations: {}
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  env: []
+    # Environment variables for metaflow-ui static deployment. Example config:
+    # - name: var_name
+    #   value: "var_value"
+
+  metaflowUIBackendURL: "http://localhost:8083/api/"
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  replicaCount: 1
+
+# values common to both the UI static and backend deployments
 imagePullSecrets: []
+podSecurityContext: {}
+  # fsGroup: 2000
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# name overrides
 nameOverride: ""
 fullnameOverride: ""
-
-env: []
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -29,27 +106,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-
-podAnnotations: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
-service:
-  type: ClusterIP
-  port: 8083
-
-serviceStatic:
-  type: ClusterIP
-  port: 3000
 
 ingress:
   enabled: false
@@ -66,38 +122,3 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-envFrom: []
-
-metadatadb:
-  port: 5432
-  password: ""
-  host: ""
-  user: ""
-
-METAFLOW_DATASTORE_SYSROOT_S3: ""

--- a/k8s/helm/metaflow/values.yaml
+++ b/k8s/helm/metaflow/values.yaml
@@ -5,6 +5,9 @@ metaflow-service:
     user: metaflow
 
 metaflow-ui:
+  # Note: for security reasons, these values should NOT be set in plain text.
+  #       Better options of passing these values are using environment variables,
+  #       kubernetes secret + values file, etc.
   metadatadb:
     password: metaflow
     name: metaflow


### PR DESCRIPTION
* refactor metaflow-ui helm chart by regrouping the input values for the ui static and backend deployment to allow separate configurations.
* expose/add input values like `metaflowUIBackendURL` and  `metaflowServiceURL` to make configuring the UI deployment easier and clearer
* Upgrade both the stack and backend docker images to the latest versions