### PR TITLE
fix for k8s Helm chart metaflow-ui db credentials

### DIFF
--- a/k8s/helm/metaflow/values.yaml
+++ b/k8s/helm/metaflow/values.yaml
@@ -8,10 +8,11 @@ metaflow-ui:
   # Note: for security reasons, these values should NOT be set in plain text.
   #       Better options of passing these values are using environment variables,
   #       kubernetes secret + values file, etc.
-  metadatadb:
-    password: metaflow
-    name: metaflow
-    user: metaflow
+  uiBackend:
+    metadatadb:
+      password: metaflow
+      name: metaflow
+      user: metaflow
 
   ingress:
     enabled: true


### PR DESCRIPTION
fixes passing of database values to metaflow-ui in the helm chart, so that environment variable values are set correctly.