### PR TITLE
fix: UI backend url with ingress

### DIFF
--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/_helpers.tpl
@@ -95,6 +95,17 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Create the backendURL, which differs if we use an ingress or not.
+*/}}
+{{- define "metaflow-ui.staticUIBackendURL" -}}
+{{- if .Values.ingress.enabled }}
+{{- default "http://localhost/api/" .Values.uiStatic.metaflowUIBackendURL }}
+{{- else }}
+{{- default "http://localhost:8083/api/" .Values.uiStatic.metaflowUIBackendURL }}
+{{- end }}
+{{- end }}
+
 {{- define "metaflow-ui.metadatadbEnvVars" -}}
 - name: MF_METADATA_DB_NAME
   value: {{ .Values.uiBackend.metadatadb.name | quote }}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
@@ -45,7 +45,7 @@ spec:
               port: http
           env:
             - name: METAFLOW_SERVICE
-              value: {{- include "metaflow-ui.staticUIBackendURL" | quote }}
+              value: {{ include "metaflow-ui.staticUIBackendURL" . | quote }}
             {{- range .Values.env }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}

--- a/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/templates/static_deployment.yaml
@@ -45,7 +45,7 @@ spec:
               port: http
           env:
             - name: METAFLOW_SERVICE
-              value:  {{ .Values.uiStatic.metaflowUIBackendURL | quote }}
+              value: {{- include "metaflow-ui.staticUIBackendURL" | quote }}
             {{- range .Values.env }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}

--- a/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
+++ b/k8s/helm/metaflow/charts/metaflow-ui/values.yaml
@@ -72,7 +72,7 @@ uiStatic:
     # - name: var_name
     #   value: "var_value"
 
-  metaflowUIBackendURL: "http://localhost:8083/api/"
+  metaflowUIBackendURL: ""
 
   service:
     type: ClusterIP


### PR DESCRIPTION
fixes the following issue with the Helm chart:

If deploying the default chart to a local cluster, the static UI will have an env var set that points to localhost:8083/api for all api requests. This is not exposed by default though, nor is it the correct url when deploying with the ingress enabled. The effect is that the UI frontend loads and is accessible, but all api requests fail due to not being reachable

changes to a conditional api url, dropping the port in case of deploying with the ingress.


Discussion: An alternative approach would be to simply add the correct `metaflowUIBackendURL: "http://localhost/api/"` to the example values.yaml. This would also document the necessity of providing a value for it.