### PR TITLE
upgrade py3.7 in lambda to py3.10

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -505,7 +505,7 @@ Resources:
   ExecuteDBMigration:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.10
       Role: !GetAtt LambdaECSExecuteRole.Arn
       Handler: index.handler
       Environment:


### PR DESCRIPTION
[AWS Lambda support for Python 3.7 is EOL](https://www.linkedin.com/posts/ozbekler_hello-everyone-aws-is-ending-support-for-activity-7108850407333888001-R1M-/), need to update the lambda in the cloud formation template.