### PR TITLE
Updated AWS CF template to use the newer version of PG (16.1)

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -596,7 +596,7 @@ Resources:
       DeleteAutomatedBackups: 'true'
       StorageType: 'gp2'
       Engine: 'postgres'
-      EngineVersion: '11'
+      EngineVersion: '16.1'
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref MyRDSSecret, ':SecretString:username}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref MyRDSSecret, ':SecretString:password}}' ]]
       VPCSecurityGroups:


### PR DESCRIPTION
Current version of CF uses an older version of PG (11) which AWS now charges extra for extended support. This change updates the template to use the latest version of PG (16.1). 

We did some minimal testing (mostly running our existing flows) with PG 16.1 on our internal Metaflow stack and it seems to work fine.