### PR TITLE
Fix Helm chart release pipeline

### DIFF
--- a/.github/workflows/publish_helm_charts.yml
+++ b/.github/workflows/publish_helm_charts.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.6.0
       with:
-        charts_dir: charts/metaflow
+        charts_dir: charts/metaflow/charts
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This change fixes the issue where the helm chart publishing action is failing

It was tested manually and is confirmed to have worked