### PR TITLE
fix duplicated labels in metaflow ui static deployment

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/templates/_helpers.tpl
+++ b/charts/metaflow/charts/metaflow-ui/templates/_helpers.tpl
@@ -56,7 +56,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{- define "metaflow-ui.labelsStatic" -}}
-{{ include "metaflow-ui.labels" . }}
 {{ include "metaflow-ui.selectorLabelsStatic" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
in helpers.tpl there are 2 labels definitions, one for backend and another for static components, but the static labels were including backend labels, which lead to label duplication and therefore installation not being successful. Here is a before/after from the static_deployment labels:

before:
```yaml
# Source: metaflow-ui/templates/static_deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "metaflow-ui-static"
  labels:
    helm.sh/chart: metaflow-ui-0.3.0
    app.kubernetes.io/name: metaflow-ui
    app.kubernetes.io/instance: metaflow-ui
    app.kubernetes.io/version: "v2.4.13"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: metaflow-ui-static
    app.kubernetes.io/instance: metaflow-ui
    app.kubernetes.io/version: "v2.4.13"
    app.kubernetes.io/managed-by: Helm
```

after:
```yaml
---
# Source: metaflow-ui/templates/static_deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "release-name-metaflow-ui-static"
  labels:
    app.kubernetes.io/name: metaflow-ui-static
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.4.13"
    app.kubernetes.io/managed-by: Helm
```
