### PR TITLE
Update ingress.yaml for charts metaflow-service

### DIFF
--- a/charts/metaflow/charts/metaflow-service/templates/ingress.yaml
+++ b/charts/metaflow/charts/metaflow-service/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "metaflow-service.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $kubeVersion := default "1.14.0" (lookup "version" "") -}}
+{{- $kubeVersion := default "1.14.0" .Capabilities.KubeVersion.Version -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" $kubeVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}


### PR DESCRIPTION
Replace lookup with .Capabilities.KubeVersion.Version, because the lookup command requires 4 paramaters and was only passed 2 which throws errors when trying to create the ingress.