### PR TITLE
Fixes #73: cleaned up duplicated labels introduced by redundant includes 

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/templates/_helpers.tpl
+++ b/charts/metaflow/charts/metaflow-ui/templates/_helpers.tpl
@@ -56,7 +56,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{- define "metaflow-ui.labelsStatic" -}}
-{{ include "metaflow-ui.labels" . }}
+helm.sh/chart: {{ include "metaflow-ui.chart" . }}
 {{ include "metaflow-ui.selectorLabelsStatic" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
`metaflow-ui.labelsStatic` should not include `metaflow-ui.labels` directly, because it defines selectors and chart related labels itself.