### PR TITLE
chore: update helm chart ui image tag

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/values.yaml
+++ b/charts/metaflow/charts/metaflow-ui/values.yaml
@@ -67,7 +67,7 @@ uiStatic:
   image:
     name: public.ecr.aws/outerbounds/metaflow_ui
     pullPolicy: IfNotPresent
-    tag: "v1.3.3"
+    tag: "v1.3.14"
 
   podAnnotations: {}
 


### PR DESCRIPTION
update static UI image tag to the latest version that also supports arm64 for users testing the chart out on arm based systems.

we could also consider unpinning the image as is the case for the other services. I'm not sure if there was a historical reason to pin the ui image version