### PR TITLE
fix: `uiStatic` release namespace as default

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/templates/static_service.yaml
+++ b/charts/metaflow/charts/metaflow-ui/templates/static_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ include "metaflow-ui.fullname-static" . }}"
-  namespace: {{ .Values.namespace | default "default" }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "metaflow-ui.labelsStatic" . | nindent 4 }}
 spec:


### PR DESCRIPTION
When the Metaflow Helm chart is applied in a k8s cluster with a non-default release namespace and `.Values.namespace` is not set or does not match the release namespace value, the `metaflow-ui-static` service will be in a different namespace than its deployment. This means that the service will never have any endpoints associated with it. 

This commit removes the template syntax to set the namespace as `default` if `.Values.namespace` is not set. 

There is a larger discrepancy here in that the UI deployments are always in the release namespace, but their services may be in a different namespace. This commit only makes the templates consistent and does not address this issue.