### PR TITLE
fix: HPA v2 for k8s 1.26+

### DIFF
--- a/charts/metaflow/charts/metaflow-service/templates/hpa.yaml
+++ b/charts/metaflow/charts/metaflow-service/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "metaflow-service.fullname"  . }}


### PR DESCRIPTION
Installing the Metaflow Helm chart beyond version `0.1.0` on supported k8s versions will cause this error:

```console
The Kubernetes API could not find version "v2beta2" of autoscaling/HorizontalPodAutoscaler for requested resource metaflow/metaflow-kubeaagentdevus1-metaflow-service. Version "v1" of autoscaling/HorizontalPodAutoscaler is installed on the destination cluster.
```

The `v2beta2` API was removed in [k8s 1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126). 

This commit bumps the version from `v2beta2` to `v2`.