### PR TITLE
fix: prioritize user-specified env vars

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
+++ b/charts/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml
@@ -49,9 +49,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          {{- with .Values.uiBackend.env }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
             - name: UI_ENABLED
               value: "1"
             - name: PATH_PREFIX
@@ -72,7 +69,10 @@ spec:
               value: {{ .Values.uiBackend.metaflowDefaultDatastore | quote }}
             - name: METAFLOW_DEFAULT_METADATA
               value: "service"
-            {{- include "metaflow-ui.metadatadbEnvVars" . | nindent 12 }}
+          {{- include "metaflow-ui.metadatadbEnvVars" . | nindent 12 }}
+          {{- with .Values.uiBackend.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.uiBackend.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Currently, user-specified env vars are treated differently between the `metaflow-service` and `metaflow-ui` Helm charts. 

In the `metaflow-service` Helm chart, user-specified env vars are placed after chart-specified env vars. In this case, K8s will treat them with priority based on order. However, in the `metaflow-ui` Helm chart, the chart-specified env vars are placed last, giving them priority. Besides being inconsistent, this is problematic as we want to set our own env vars that conflict with the chart-specified env vars (in this case, `MF_METADATA_DB_USER` and `MF_METADATA_DB_PSWD`). 

This commit switches the layout of the `metaflow-ui` env vars to prioritize user-specified over chart-specified env vars. 

`metaflow-service` layout: https://github.com/outerbounds/metaflow-tools/blob/d24572c0a1610410ff586f1cd87312edc1c34cf1/charts/metaflow/charts/metaflow-service/templates/deployment.yaml#L73-L75

`metaflow-ui` layout: https://github.com/outerbounds/metaflow-tools/blob/d24572c0a1610410ff586f1cd87312edc1c34cf1/charts/metaflow/charts/metaflow-ui/templates/backend_deployment.yaml#L51-L75