### PR TITLE
update metaflow-service and metaflow-ui image tags

### DIFF
--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -92,7 +92,7 @@ Mappings:
     ServiceName:
       value: 'metadata-service-v2'
     ImageUrl:
-      value: 'netflixoss/metaflow_metadata_service:v2.4.12'
+      value: 'netflixoss/metaflow_metadata_service:v2.5.0'
     ContainerPort:
       value: 8080
     ContainerCpu:
@@ -113,7 +113,7 @@ Mappings:
     ServiceName:
       value: 'metaflow-ui-service'
     ImageUrl:
-      value: 'netflixoss/metaflow_metadata_service:v2.4.12'
+      value: 'netflixoss/metaflow_metadata_service:v2.5.0'
     ContainerPort:
       value: 8083
     ContainerCpu:

--- a/aws/cloudformation/metaflow-cfn-template.yml
+++ b/aws/cloudformation/metaflow-cfn-template.yml
@@ -134,7 +134,7 @@ Mappings:
     ServiceName:
       value: 'metadata-ui-static'
     ImageUrl:
-      value: 'public.ecr.aws/outerbounds/metaflow_ui:v1.2.4'
+      value: 'public.ecr.aws/outerbounds/metaflow_ui:v1.3.14'
     ContainerPort:
       value: 3000
     ContainerCpu:

--- a/azure/terraform/variables.tf
+++ b/azure/terraform/variables.tf
@@ -19,9 +19,9 @@ locals {
   k8s_subnet_name = "snet-${var.org_prefix}-metaflow-k8s-${local.location}-${terraform.workspace}"
 
   # Changeable after initial "terraform apply" (e.g. image upgrades, secret rotation)
-  metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
+  metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
-  metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
+  metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_kubernetes_secret_name = "metaflow-azure-storage-credentials"
 
   # Forever constants

--- a/azure/terraform/variables.tf
+++ b/azure/terraform/variables.tf
@@ -20,7 +20,7 @@ locals {
 
   # Changeable after initial "terraform apply" (e.g. image upgrades, secret rotation)
   metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
-  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
+  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.3.14"
   metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_kubernetes_secret_name = "metaflow-azure-storage-credentials"
 

--- a/charts/metaflow/charts/metaflow-ui/values.yaml
+++ b/charts/metaflow/charts/metaflow-ui/values.yaml
@@ -67,7 +67,7 @@ uiStatic:
   image:
     name: public.ecr.aws/outerbounds/metaflow_ui
     pullPolicy: IfNotPresent
-    tag: "v1.3.3"
+    tag: "v1.3.14"
 
   podAnnotations: {}
 

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -18,7 +18,7 @@ locals {
 
   airflow_logs_bucket_path = "gs://${local.storage_bucket_name}/airflow/logs"
 
-  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
+  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.3.14"
   metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metadata_service_image            = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   # TODO gsa-metaflow-workload-id-<workspace>

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -19,9 +19,8 @@ locals {
   airflow_logs_bucket_path = "gs://${local.storage_bucket_name}/airflow/logs"
 
   metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
-  # metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
-  metaflow_ui_backend_service_image = "jackieob/metadata_service:gcp.rc1"
-  metadata_service_image            = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
+  metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
+  metadata_service_image            = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   # TODO gsa-metaflow-workload-id-<workspace>
   metaflow_workload_identity_gsa_name = "gsa-metaflow-${terraform.workspace}"
 

--- a/nebius/terraform/variables.tf
+++ b/nebius/terraform/variables.tf
@@ -10,9 +10,9 @@ locals {
   storage_account_name = "stmetaflow${terraform.workspace}"
 
   # Changeable after initial "terraform apply" (e.g. image upgrades, secret rotation)
-  metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
+  metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
-  metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.3.3"
+  metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_kubernetes_secret_name = "metaflow-nebius-storage-credentials"
 
   # Forever constants

--- a/nebius/terraform/variables.tf
+++ b/nebius/terraform/variables.tf
@@ -11,7 +11,7 @@ locals {
 
   # Changeable after initial "terraform apply" (e.g. image upgrades, secret rotation)
   metadata_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
-  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.4"
+  metaflow_ui_static_service_image = "public.ecr.aws/outerbounds/metaflow_ui:v1.3.14"
   metaflow_ui_backend_service_image = "public.ecr.aws/outerbounds/metaflow_metadata_service:2.5.0"
   metaflow_kubernetes_secret_name = "metaflow-nebius-storage-credentials"
 


### PR DESCRIPTION
- updates metaflow-service to `2.5.0` in order to support spin steps
- updates metaflow-ui to `1.3.14` as the most recent one
- updates metaflow-service in GCP template to the official one instead of Jackie's fork

closes #90 