### PR TITLE
feat(charts/metaflow-service): apply security context to db-migrations init container

### DIFF
--- a/charts/metaflow/charts/metaflow-service/templates/deployment.yaml
+++ b/charts/metaflow/charts/metaflow-service/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       {{- if .Values.dbMigrations.runOnStart }}
       initContainers:
         - name: db-migrations
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
           - "/opt/latest/bin/python3"


### PR DESCRIPTION
Without this, running with restricted pod security policy is not possible as Kubernetes rejects scheduling the pod.