### PR TITLE
fix: add service annotations support to `metaflow-ui` services

### DIFF
--- a/charts/metaflow/charts/metaflow-ui/templates/backend_service.yaml
+++ b/charts/metaflow/charts/metaflow-ui/templates/backend_service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "metaflow-ui.labels" . | nindent 4 }}
+  {{- with .Values.uiBackend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.uiBackend.service.type }}
   ports:

--- a/charts/metaflow/charts/metaflow-ui/templates/static_service.yaml
+++ b/charts/metaflow/charts/metaflow-ui/templates/static_service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Values.namespace | default "default" }}
   labels:
     {{- include "metaflow-ui.labelsStatic" . | nindent 4 }}
+  {{- with .Values.uiStatic.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.uiStatic.service.type }}
   loadBalancerIP: {{ .Values.uiStatic.service.loadBalancerIP | default "" }}


### PR DESCRIPTION
The `metaflow-service` subchart already supports `service.annotations` ([service.yaml:7-10](https://github.com/outerbounds/metaflow-tools/blob/main/charts/metaflow/charts/metaflow-service/templates/service.yaml#L7-L10)), but the `metaflow-ui` subchart does not. This makes it impossible to set per-service annotations on the UI backend and static frontend services.

This is needed for deployments using the AWS Load Balancer Controller, where per-service `alb.ingress.kubernetes.io/healthcheck-path` annotations are required to configure different healthcheck paths per target group (the backend responds on `/api/ping`, the static frontend on `/`). Without service-level annotation support, the only workaround is vendoring the chart or creating duplicate Service resources.

This PR adds `{{- with .Values.uiBackend.service.annotations }}` and `{{- with .Values.uiStatic.service.annotations }}` blocks to `backend_service.yaml` and `static_service.yaml`, following the exact pattern already used in `metaflow-service`.

Example usage:

```yaml
metaflow-ui:
  uiBackend:
    service:
      annotations:
        alb.ingress.kubernetes.io/healthcheck-path: /api/ping
  uiStatic:
    service:
      annotations:
        alb.ingress.kubernetes.io/healthcheck-path: /
```

Backward compatible — no annotations are rendered when none are configured.